### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=ArduinoLibraryTemplate
+version=0.0.0
+author=Otacilio Saraiva Maia Neto
+maintainer=Otacilio Saraiva Maia Neto
+sentence=An Open Source template to build Arduino Libraries.
+paragraph=Provide a further description here, that does not repeat the sentence above.
+category=Other
+url=https://github.com/OtacilioN/ArduinoLibraryTemplate
+architectures=*
+includes=Template.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata